### PR TITLE
Update Vercel config for Python API

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,3 +2,6 @@
 fastapi==0.104.1
 uvicorn==0.24.0
 asyncpg==0.29.0
+numpy>=1.20.0
+scipy>=1.7.0
+geopy>=2.0.0

--- a/vercel.json
+++ b/vercel.json
@@ -11,13 +11,13 @@
       "src": "api/main.py",
       "use": "@vercel/python",
       "config": {
-        "runtime": "python3.9"
+        "runtime": "python3.12"
       }
     }
   ],
   "functions": {
     "api/main.py": {
-      "runtime": "python3.9",
+      "runtime": "python3.12",
       "maxDuration": 30
     }
   },


### PR DESCRIPTION
- Add numpy, scipy, and geopy to api/requirements.txt
- Update Python runtime to 3.12 in vercel.json
- Remind user to set SUPABASE_DB_URL and update CORS origins.